### PR TITLE
Append 8-digit commit sha to end of image tag for feature branches

### DIFF
--- a/.github/workflows/generate_tag.yaml
+++ b/.github/workflows/generate_tag.yaml
@@ -23,7 +23,7 @@ jobs:
         run: |
           branch=$(echo \"${{ github.ref_name }}\" | sed -e 's/feature\///g' -e 's/_/-/g' -e 's/[^0-9a-zA-Z\-]*//g' -e 's/^-*//g' | awk '{print tolower($0)}')
           sha=$(echo ${{ github.sha }} | cut -c 1-8)
-          echo "tag=$(printf \"%s-%s\" \"$branch\" \"sha\")" >> $GITHUB_ENV
+          echo "tag=$(printf \"%s-%s\" $branch $sha)" >> $GITHUB_ENV
 
       - name: If the ref is master/relase, set the tag to the first 8 of the commit sha
         if: ${{ github.ref_name == github.event.repository.default_branch }}

--- a/.github/workflows/generate_tag.yaml
+++ b/.github/workflows/generate_tag.yaml
@@ -20,7 +20,10 @@ jobs:
       - name: If the ref is feature branch, lowercase it and replace all special chars with hyphens
         if: startsWith(github.ref_name, 'feature/')
         # Remove "feature/", replace underscores with dashes, remove special characters, remove leading dashes
-        run: echo "tag=$(echo \"${{ github.ref_name }}\" | sed -e 's/feature\///g' -e 's/_/-/g' -e 's/[^0-9a-zA-Z\-]*//g' -e 's/^-*//g' | awk '{print tolower($0)}')" >> $GITHUB_ENV
+        run: |
+          branch=$(echo \"${{ github.ref_name }}\" | sed -e 's/feature\///g' -e 's/_/-/g' -e 's/[^0-9a-zA-Z\-]*//g' -e 's/^-*//g' | awk '{print tolower($0)}')
+          sha=$(echo ${{ github.sha }} | cut -c 1-8)
+          echo "tag=$(printf \"%s-%s\" \"$branch\" \"sha\")" >> $GITHUB_ENV
 
       - name: If the ref is master/relase, set the tag to the first 8 of the commit sha
         if: ${{ github.ref_name == github.event.repository.default_branch }}


### PR DESCRIPTION
## Description of the change

This PR adds the 8-digit commit sha to the end of image tags generated for feature branch images.

## Changes

* .github/workflows/generate_tag.yaml - commit sha is appended to the end of the image tag for feature branch images

## Risk (answer all applicable; leave blank if "no")

### *Does this affect dev? (If yes, explain)*

- [ ] Yes

### *Does this affect stage? (If yes, explain)*

- [ ] Yes

### *Does this affect prod? (If yes, explain)*

- [ ] Yes

### *Does this affect security configs? (If yes, explain)*

- [ ] Yes

### *Does this affect deployment configs? (If yes, explain)*

- [x] Yes - the image tags referenced by feature environments will need to change slightly. Argo-cd annotations should be added to grab the latest tag for a particular branch.

### *Does this affect infrastructure configs? (If yes, explain)*

- [ ] Yes

