### PR TITLE
Don't use the default branch in logic for tagging

### DIFF
--- a/.github/workflows/generate_tag.yaml
+++ b/.github/workflows/generate_tag.yaml
@@ -13,7 +13,7 @@ jobs:
     outputs:
       tag: ${{ steps.set-output.outputs.tag }}
     steps:
-      - name: If the ref is a tag, remove the leading v
+      - name: If the ref is a git tag, remove the leading v
         if: ${{ github.ref_type == 'tag' && startsWith(github.ref_name, 'v') }}
         run: echo "tag=$(echo \"${{ github.ref_name }}\" | sed -e 's/v//1' )" >> $GITHUB_ENV
 
@@ -25,8 +25,8 @@ jobs:
           sha=$(echo ${{ github.sha }} | cut -c 1-8)
           echo "tag=$(printf \"%s-%s\" $branch $sha)" >> $GITHUB_ENV
 
-      - name: If the ref is master/relase, set the tag to the first 8 of the commit sha
-        if: ${{ github.ref_name == github.event.repository.default_branch }}
+      - name: If not a git tag or feature branch, set the image tag to the first 8 of the commit sha
+        if: ${{ github.ref_type != 'tag' && !startsWith(github.ref_name, 'feature/') }}
         run: echo "tag=$(echo ${{ github.sha }} | cut -c 1-8)" >> $GITHUB_ENV  
 
       - name: Set output


### PR DESCRIPTION
## Description of the change

This PR changes the logic for our generate_tag workflow so that it does not use the repository's default branch. Rather, if the event is not a tag event and the branch does not start with "feature/", the image tag will be the 8-digit commit sha. This makes the 8-digit commit sha the default tag (if no other conditions are met), and pushes the decision about whether or not a tag should be generated back to the calling workflow.

## Changes

* .github/workflows/generate_tag.yaml - updated logic to not use the repository's default branch and instead use the 8-digit commit sha if no other conditions are met

## Impact

* Any infrastructure related impact
* Any security related impact
