### PR TITLE
Remove unnecessary quotes from around the tag

### DIFF
--- a/.github/actions/generate-tag/action.yaml
+++ b/.github/actions/generate-tag/action.yaml
@@ -5,16 +5,16 @@ runs:
     - name: If the ref is a git tag, remove the leading v
       if: ${{ github.ref_type == 'tag' && startsWith(github.ref_name, 'v') }}
       shell: bash
-      run: echo "tag=$(echo \"${{ github.ref_name }}\" | sed -e 's/v//1' )" >> $GITHUB_ENV
+      run: echo "tag=$(echo ${{ github.ref_name }} | sed -e 's/v//1' )" >> $GITHUB_ENV
 
     - name: If the ref is feature branch, lowercase it and replace all special chars with hyphens
       if: startsWith(github.ref_name, 'feature/')
       # Remove "feature/", replace underscores with dashes, remove special characters, remove leading dashes
       shell: bash
       run: |
-        branch=$(echo \"${{ github.ref_name }}\" | sed -e 's/feature\///g' -e 's/_/-/g' -e 's/[^0-9a-zA-Z\-]*//g' -e 's/^-*//g' | awk '{print tolower($0)}')
+        branch=$(echo ${{ github.ref_name }} | sed -e 's/feature\///g' -e 's/_/-/g' -e 's/[^0-9a-zA-Z\-]*//g' -e 's/^-*//g' | awk '{print tolower($0)}')
         sha=$(echo ${{ github.sha }} | cut -c 1-8)
-        echo "tag=$(printf \"%s-%s\" $branch $sha)" >> $GITHUB_ENV
+        echo "tag=$(printf %s-%s $branch $sha)" >> $GITHUB_ENV
 
     - name: If not a git tag or feature branch, set the image tag to the first 8 of the commit sha
       if: ${{ github.ref_type != 'tag' && !startsWith(github.ref_name, 'feature/') }}


### PR DESCRIPTION
Quotes were surrounding the resulting tag from this action. This breaks the docker build command. We need the quotes to be removed from the action.