### PR TITLE
Create composite action for build/push

### DIFF
--- a/.github/actions/build-push-ecr/action.yaml
+++ b/.github/actions/build-push-ecr/action.yaml
@@ -45,6 +45,21 @@ inputs:
     type: string
     required: false
     default: ""
+  docker-username:
+    description: "Username for Docker account"
+    type: string
+    required: false
+    default: ""
+  docker-password:
+    description: "Password for Docker account"
+    type: string
+    required: false
+    default: ""
+  docker-registry:
+    description: "Docker registry to push images to"
+    type: string
+    required: false
+    default: "oci://registry-1.docker.io/philinc"
 runs:
   using: "composite"
   steps:
@@ -75,9 +90,20 @@ runs:
       webhookUrl: ${{ inputs.google-chat-webhook }}
       status: ${{ job.status }}
 
-  - name: Push
+  - name: Push to ECR
     if: ${{ inputs.push }}
     run: docker push ${{ steps.login-ecr.outputs.registry }}/${{ inputs.name }}:${{ inputs.tag }}
+
+  - name: Login to DockerHub
+    if: ${{ inputs.push }}
+    run: docker login -u ${{ inputs.docker-username }} -p ${{ inputs.docker-password }}
+
+  - name: Tag for DockerHub
+    run: docker tag ${{ steps.login-ecr.outputs.registry }}/${{ inputs.name }}:${{ inputs.tag }} ${{ inputs.docker-registry }}/${{ inputs.name }}:${{ inputs.tag }}
+
+  - name: Push to DockerHub
+    if: ${{ inputs.push }}
+    run: docker push ${{ inputs.docker-registry }}/${{ inputs.name }}:${{ inputs.tag }}
 
   - name: Notify Push
     if: ${{ inputs.notify }} && ${{ inputs.push }}

--- a/.github/actions/build-push-ecr/action.yaml
+++ b/.github/actions/build-push-ecr/action.yaml
@@ -1,0 +1,89 @@
+---
+name: 'Build and Push to ECR'
+description: Runs a docker build, then pushes the image to ECR
+inputs:
+  name:
+    description: "Name of project"
+    type: string
+    required: true
+  tag:
+    description: "Tag to associate with built image"
+    type: string
+    required: true
+  aws-access-key-id:
+    description: "Access key for AWS account"
+    type: string
+    required: false
+    default: ""
+  aws-secret-access-key:
+    description: "Secret key for AWS account"
+    type: string
+    required: false
+    default: ""
+  region:
+    description: "Push into this AWS region"
+    type: string
+    required: false
+    default: "us-east-1"
+  push:
+    description: "Whether or not to push the image to the registry"
+    type: boolean
+    required: false
+    default: false
+  dockerfile:
+    description: "A path to a Dockerfile to build"
+    type: string
+    required: false
+    default: "Dockerfile"
+  notify:
+    description: "Whether or not to send a message to gchat"
+    type: boolean
+    required: false
+    default: false
+  google-chat-webhook:
+    description: "Webhook for sending a google chat notification"
+    type: string
+    required: false
+    default: ""
+runs:
+  using: "composite"
+  steps:
+  - uses: actions/checkout@v3
+
+  - name: Configure AWS credentials
+    if: ${{ inputs.push }}
+    uses: aws-actions/configure-aws-credentials@v2
+    with:
+      aws-access-key-id: ${{ inputs.aws-access-key-id }}
+      aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
+      aws-region: ${{ inputs.region }}
+  
+  - name: Login to Amazon ECR
+    if: ${{ inputs.push }}
+    id: login-ecr
+    uses: aws-actions/amazon-ecr-login@v1
+        
+  - name: Build
+    run: docker build . -t ${{ steps.login-ecr.outputs.registry }}/${{ inputs.name }}:${{ inputs.tag }} -f ${{ inputs.dockerfile }}
+
+  - name: Notify Build
+    if: ${{ inputs.notify }}
+    uses: nakamuraos/google-chat-notifications@v2.0.1
+    with:
+      title: Build
+      subtitle: ${{ github.event.head_commit.message }}
+      webhookUrl: ${{ inputs.google-chat-webhook }}
+      status: ${{ job.status }}
+
+  - name: Push
+    if: ${{ inputs.push }}
+    run: docker push ${{ steps.login-ecr.outputs.registry }}/${{ inputs.name }}:${{ inputs.tag }}
+
+  - name: Notify Push
+    if: ${{ inputs.notify }} && ${{ inputs.push }}
+    uses: nakamuraos/google-chat-notifications@v2.0.1
+    with:
+      title: Push
+      subtitle: ${{ github.event.head_commit.message }}
+      webhookUrl: ${{ inputs.google-chat-webhook}}
+      status: ${{ job.status }}

--- a/.github/actions/build-push/action.yaml
+++ b/.github/actions/build-push/action.yaml
@@ -1,6 +1,6 @@
 ---
-name: 'Build and Push to ECR'
-description: Runs a docker build, then pushes the image to ECR
+name: 'Build and Push to ECR and DockerHub'
+description: Runs a docker build, then pushes the image to ECR and DockerHub
 inputs:
   name:
     description: "Name of project"
@@ -26,7 +26,7 @@ inputs:
     required: false
     default: "us-east-1"
   push:
-    description: "Whether or not to push the image to the registry"
+    description: "Whether or not to push the image to ECR and DockerHub"
     type: boolean
     required: false
     default: false


### PR DESCRIPTION
Composite actions are better for our use case than reusable workflows because we can run multiple actions sequentially on the same worker. Each workflow requires a new worker, and we get charged for a full minute of runtime no matter how long the worker actually runs. This PR creates a composite action for building/pushing images that we can use to replace the existing build/push reusable workflow.