### PR TITLE
Corrected repository reference

### DIFF
--- a/.github/actions/build-push/action.yaml
+++ b/.github/actions/build-push/action.yaml
@@ -59,7 +59,7 @@ inputs:
     description: "Docker registry to push images to"
     type: string
     required: false
-    default: "oci://registry-1.docker.io/philinc"
+    default: "philinc"
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
I had a bad default value in the build-push action. This updates it to be a valid repository reference.