### PR TITLE
Use docker registry for tag in build step

### DIFF
--- a/.github/actions/build-push/action.yaml
+++ b/.github/actions/build-push/action.yaml
@@ -65,22 +65,9 @@ runs:
   steps:
   - uses: actions/checkout@v3
 
-  - name: Configure AWS credentials
-    if: ${{ inputs.push == true }}
-    uses: aws-actions/configure-aws-credentials@v2
-    with:
-      aws-access-key-id: ${{ inputs.aws-access-key-id }}
-      aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
-      aws-region: ${{ inputs.region }}
-  
-  - name: Login to Amazon ECR
-    if: ${{ inputs.push == true }}
-    id: login-ecr
-    uses: aws-actions/amazon-ecr-login@v1
-        
   - name: Build
     shell: bash
-    run: docker build . -t ${{ steps.login-ecr.outputs.registry }}/${{ inputs.name }}:${{ inputs.tag }} -f ${{ inputs.dockerfile }}
+    run: docker build . -t ${{ inputs.docker-registry }}/${{ inputs.name }}:${{ inputs.tag }} -f ${{ inputs.dockerfile }}
 
   - name: Notify Build
     if: ${{ inputs.notify == true }}
@@ -91,24 +78,38 @@ runs:
       webhookUrl: ${{ inputs.google-chat-webhook }}
       status: ${{ job.status }}
 
-  - name: Push to ECR
-    if: ${{ inputs.push  == true }}
-    shell: bash
-    run: docker push ${{ steps.login-ecr.outputs.registry }}/${{ inputs.name }}:${{ inputs.tag }}
-
   - name: Login to DockerHub
-    if: ${{ inputs.push  == true }}
+    if: ${{ inputs.push == true }}
     shell: bash
     run: docker login -u ${{ inputs.docker-username }} -p ${{ inputs.docker-password }}
-
-  - name: Tag for DockerHub
-    shell: bash
-    run: docker tag ${{ steps.login-ecr.outputs.registry }}/${{ inputs.name }}:${{ inputs.tag }} ${{ inputs.docker-registry }}/${{ inputs.name }}:${{ inputs.tag }}
 
   - name: Push to DockerHub
     if: ${{ inputs.push == true }}
     shell: bash
     run: docker push ${{ inputs.docker-registry }}/${{ inputs.name }}:${{ inputs.tag }}
+
+  - name: Configure AWS credentials
+    if: ${{ inputs.push == true }}
+    uses: aws-actions/configure-aws-credentials@v2
+    with:
+      aws-access-key-id: ${{ inputs.aws-access-key-id }}
+      aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
+      aws-region: ${{ inputs.region }}
+  
+  - name: Login to ECR
+    if: ${{ inputs.push == true }}
+    id: login-ecr
+    uses: aws-actions/amazon-ecr-login@v1
+
+  - name: Tag for ECR
+    if: ${{ inputs.push == true }}
+    shell: bash
+    run: docker tag ${{ inputs.docker-registry }}/${{ inputs.name }}:${{ inputs.tag }} ${{ steps.login-ecr.outputs.registry }}/${{ inputs.name }}:${{ inputs.tag }} 
+
+  - name: Push to ECR
+    if: ${{ inputs.push == true }}
+    shell: bash
+    run: docker push ${{ steps.login-ecr.outputs.registry }}/${{ inputs.name }}:${{ inputs.tag }}
 
   - name: Notify Push
     if: ${{ inputs.notify == true && inputs.push == true }}


### PR DESCRIPTION
We were not always logging into ECR but were using the output from the login step in the tag for the build step. This reorders the build steps so that the docker registry is used in the build step instead, which removes the need for logging into ECR if we're not pushing the image.