### PR TITLE
Output the ECR registry so that if we need to use it again, we can

### DIFF
--- a/.github/actions/build-push/action.yaml
+++ b/.github/actions/build-push/action.yaml
@@ -60,6 +60,10 @@ inputs:
     type: string
     required: false
     default: "philinc"
+outputs:
+  ecr-registry:
+    description: "ECR registry for use with any other tags/pushes"
+    value: ${{ steps.login-ecr.outputs.registry }}
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
Git-sync also tags images as `latest`, but the build-push action doesn't currently allow multiple tags to be passed in. I also don't want to run the full build action twice. Outputting the ECR registry allows us to continue performing docker tag/push actions outside of the build-push composite action without repeating the whole thing.