### PR TITLE
Assume the role for 10 minutes, remove verbosity from tar command

### DIFF
--- a/.github/actions/archive-repo/action.yaml
+++ b/.github/actions/archive-repo/action.yaml
@@ -44,7 +44,7 @@ runs:
       mkdir archive
       git fetch
       git archive HEAD | gzip > ./archive/repo.tar.gz
-      tar -czvf ./archive/git.tar.gz .git
+      tar -czf ./archive/git.tar.gz .git
   - name: Configure AWS credentials
     uses: aws-actions/configure-aws-credentials@v2
     with:
@@ -53,6 +53,7 @@ runs:
       aws-region: ${{ inputs.region }}
       role-to-assume: ${{ inputs.assume-role }}
       role-session-name: CodeArchival
+      role-duration-seconds: 600
   - name: Upload to S3
     shell: bash
     run: |


### PR DESCRIPTION
This should stop the errors from using the default role duration