### PR TITLE
Upgrade amazon-ecr-login to newest version

### DIFF
--- a/.github/actions/build-push/action.yaml
+++ b/.github/actions/build-push/action.yaml
@@ -103,7 +103,7 @@ runs:
   - name: Login to ECR
     if: ${{ inputs.push == 'true' }}
     id: login-ecr
-    uses: aws-actions/amazon-ecr-login@v1
+    uses: aws-actions/amazon-ecr-login@v2
 
   - name: Tag for ECR
     if: ${{ inputs.push == 'true' }}

--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -78,7 +78,7 @@ jobs:
       - name: Login to Amazon ECR
         if: ${{ inputs.push }}
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2
 
       - name: Tag for ECR
         if: ${{ inputs.push }}

--- a/.github/workflows/build_push_ecr.yaml
+++ b/.github/workflows/build_push_ecr.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Login to Amazon ECR
         if: ${{ inputs.push }}
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2
             
       - name: Build
         run: docker build . -t ${{ steps.login-ecr.outputs.registry }}/${{ inputs.name }}:${{ inputs.tag }} -f ${{ inputs.dockerfile }}


### PR DESCRIPTION
Upgrades the amazon-ecr-login action to the latest version to automatically mask docker credentials. As far as I can tell, we are not using them anywhere.