### PR TITLE
Upgrade aws-configure-credentials to latest version

### DIFF
--- a/.github/actions/build-push/action.yaml
+++ b/.github/actions/build-push/action.yaml
@@ -94,7 +94,7 @@ runs:
 
   - name: Configure AWS credentials
     if: ${{ inputs.push == 'true' }}
-    uses: aws-actions/configure-aws-credentials@v2
+    uses: aws-actions/configure-aws-credentials@v4
     with:
       aws-access-key-id: ${{ inputs.aws-access-key-id }}
       aws-secret-access-key: ${{ inputs.aws-secret-access-key }}

--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Configure AWS credentials
         if: ${{ inputs.push }}
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/build_push_ecr.yaml
+++ b/.github/workflows/build_push_ecr.yaml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Configure AWS credentials
         if: ${{ inputs.push }}
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
The configure-aws-credentials action was getting a deprecation warning. This resolves it by upgrading to v4.